### PR TITLE
Support plugin specific log level

### DIFF
--- a/lib/fluent/plugin/out_azurefunctions.rb
+++ b/lib/fluent/plugin/out_azurefunctions.rb
@@ -4,6 +4,10 @@ module Fluent
   class AzureFunctionsOutput < BufferedOutput
     Plugin.register_output('azurefunctions', self)
 
+    unless method_defined?(:log)
+      define_method('log') { $log }
+    end
+
     def initialize
       super
       require 'msgpack'
@@ -95,7 +99,7 @@ module Fluent
         begin
           @client.post(payload)
         rescue Exception => ex
-          $log.fatal "Error occured in posting to Azure Functions HTTP trigger function: " 
+          log.fatal "Error occured in posting to Azure Functions HTTP trigger function: "
                   + "'#{ex}', .rid=>#{unique_identifier}, payload=>" + payload
         end
       }


### PR DESCRIPTION
Recent Fluentd supports plugin specific log level with `@log_level`
parameter.

```aconf
<match **>
  @type azurefunctions
  @log_level warn
  # etc.
</match>
```