### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-azurefunctions.gemspec
+++ b/fluent-plugin-azurefunctions.gemspec
@@ -18,10 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|gem|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
+  gem.add_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_dependency "rest-client"
   gem.add_development_dependency "bundler", "~> 1.11"
   gem.add_development_dependency "rake", "~> 10.0"
   gem.add_development_dependency "test-unit"
 end
-

--- a/lib/fluent/plugin/out_azurefunctions.rb
+++ b/lib/fluent/plugin/out_azurefunctions.rb
@@ -13,10 +13,6 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
 
-    def initialize
-      super
-    end
-
     config_param :endpoint, :string,
                  :desc => "Azure Functions Endpoint URL"
     config_param :function_key, :string, :secret => true,

--- a/lib/fluent/plugin/out_azurefunctions.rb
+++ b/lib/fluent/plugin/out_azurefunctions.rb
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 
 require 'fluent/plugin/output'
+require 'msgpack'
+require 'time'
+require 'fluent/plugin/azurefunctions/client'
 
 module Fluent::Plugin
   class AzureFunctionsOutput < Output
@@ -12,9 +15,6 @@ module Fluent::Plugin
 
     def initialize
       super
-      require 'msgpack'
-      require 'time'
-      require 'fluent/plugin/azurefunctions/client'
     end
 
     config_param :endpoint, :string,

--- a/lib/fluent/plugin/out_azurefunctions.rb
+++ b/lib/fluent/plugin/out_azurefunctions.rb
@@ -10,10 +10,6 @@ module Fluent::Plugin
 
     DEFAULT_BUFFER_TYPE = "memory"
 
-    unless method_defined?(:log)
-      define_method('log') { $log }
-    end
-
     def initialize
       super
       require 'msgpack'

--- a/lib/fluent/plugin/out_azurefunctions.rb
+++ b/lib/fluent/plugin/out_azurefunctions.rb
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 
-module Fluent
-  class AzureFunctionsOutput < BufferedOutput
-    Plugin.register_output('azurefunctions', self)
+require 'fluent/plugin/output'
+
+module Fluent::Plugin
+  class AzureFunctionsOutput < Output
+    Fluent::Plugin.register_output('azurefunctions', self)
+
+    helpers :compat_parameters
+
+    DEFAULT_BUFFER_TYPE = "memory"
 
     unless method_defined?(:log)
       define_method('log') { $log }
@@ -34,20 +40,25 @@ module Fluent
     config_param :tag_field_name, :string, :default => "tag",
                  :desc => "This is required only when add_time_field is true"
 
+    config_section :buffer do
+      config_set_default :@type, DEFAULT_BUFFER_TYPE
+    end
+
     def configure(conf)
+      compat_parameters_convert(conf, :buffer)
       super
-      raise ConfigError, 'no endpoint' if @endpoint.empty?
-      raise ConfigError, 'no function_key' if @function_key.empty?
+      raise Fluent::ConfigError, 'no endpoint' if @endpoint.empty?
+      raise Fluent::ConfigError, 'no function_key' if @function_key.empty?
       if not @key_names.nil?
         @key_names = @key_names.split(',')
       end
       if @add_time_field and @time_field_name.empty?
-        raise ConfigError, 'time_field_name must be set if add_time_field is true'
+        raise Fluent::ConfigError, 'time_field_name must be set if add_time_field is true'
       end
       if @add_tag_field and @tag_field_name.empty?
-        raise ConfigError, 'tag_field_name must be set if add_tag_field is true'
+        raise Fluent::ConfigError, 'tag_field_name must be set if add_tag_field is true'
       end
-      @timef = TimeFormatter.new(@time_format, @localtime)
+      @timef = Fluent::TimeFormatter.new(@time_format, @localtime)
     end
 
     def start
@@ -88,6 +99,14 @@ module Fluent
         record = record.merge(r)
       end
       record.to_msgpack
+    end
+
+    def formatted_to_msgpack_binary?
+      true
+    end
+
+    def multi_workers_ready?
+      true
     end
 
     def write(chunk)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,7 +23,10 @@ unless ENV.has_key?('VERBOSE')
   $log = nulllogger
 end
 
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 require 'fluent/plugin/out_azurefunctions'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end

--- a/test/plugin/test_azurefunctions.rb
+++ b/test/plugin/test_azurefunctions.rb
@@ -20,69 +20,77 @@ class AzureFunctionsOutputTest < Test::Unit::TestCase
   #   utc
   # ]
 
-  def create_driver(conf = CONFIG, tag='azurefunctions.test')
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::AzureFunctionsOutput, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::AzureFunctionsOutput).configure(conf)
   end
 
   def test_configure
-    #### set configurations
-    # d = create_driver %[
-    #   path test_path
-    #   compress gz
-    # ]
-    #### check configurations
-    # assert_equal 'test_path', d.instance.path
-    # assert_equal :gz, d.instance.compress
+    d = create_driver
+
+    assert_equal 'https://yoichikademo1.azurewebsites.net/api/HttpTriggerFunction',
+                 d.instance.endpoint
+    assert_equal 'aRVQ7Lj0vzDhY0JBYF8gpDzDCyEBxLwhO51JSC7X5dZFbTvROs7uNg==',
+                 d.instance.function_key
+    assert_equal ["postid", "user", "content", "tag"], d.instance.key_names
+    assert_true d.instance.localtime
+    assert_true d.instance.add_time_field
+    assert_equal 'time', d.instance.time_field_name
+    assert_true d.instance.add_tag_field
+    assert_equal 'tag', d.instance.tag_field_name
   end
 
   def test_format
     d = create_driver
 
-    # time = Time.parse("2011-01-02 13:14:15 UTC").to_i
-    # d.emit({"a"=>1}, time)
-    # d.emit({"a"=>2}, time)
+    time = event_time("2011-01-02 13:14:15 UTC")
+    d.run(default_tag: 'documentdb.test') do
+      d.feed(time, {"a"=>1})
+      d.feed(time, {"a"=>2})
+    end
 
-    # d.expect_format %[2011-01-02T13:14:15Z\ttest\t{"a":1}\n]
-    # d.expect_format %[2011-01-02T13:14:15Z\ttest\t{"a":2}\n]
-
-    # d.run
+    # assert_equal EXPECTED1, d.formatted[0]
+    # assert_equal EXPECTED2, d.formatted[1]
   end
 
   def test_write
     d = create_driver
 
-    time = Time.parse("2016-01-28 13:14:15 UTC").to_i
-    d.emit(
-        {
-            "postid" => "10001",
-            "user"=> "ladygaga",
-            "content" => "post by ladygaga",
-            "tag" => "azurefunctions.debug",
-            "posttime" =>"2016-11-31T00:00:00Z"
-        }, time)
+    time = event_time("2016-01-28 13:14:15 UTC")
+    data = d.run(default_tag: 'azurefunctions.test') do
+      d.feed(
+          time,
+          {
+              "postid" => "10001",
+              "user"=> "ladygaga",
+              "content" => "post by ladygaga",
+              "tag" => "azurefunctions.debug",
+              "posttime" =>"2016-11-31T00:00:00Z"
+          })
 
-    d.emit(
-        {
-            "postid" => "10002",
-            "user"=> "katyperry",
-            "content" => "post by katyperry",
-            "tag" => "azurefunctions.debug",
-            "posttime" =>"2016-11-31T00:00:00Z"
-        }, time)
+      d.feed(
+          time,
+          {
+              "postid" => "10002",
+              "user"=> "katyperry",
+              "content" => "post by katyperry",
+              "tag" => "azurefunctions.debug",
+              "posttime" =>"2016-11-31T00:00:00Z"
+          })
 
-    d.emit(
-        {
-            "postid" => "10003",
-            "tag" => "azurefunctions.debug",
-            "time" =>"2016-11-31T00:00:00Z"
-        }, time)
+      d.feed(
+          time,
+          {
+              "postid" => "10003",
+              "tag" => "azurefunctions.debug",
+              "time" =>"2016-11-31T00:00:00Z"
+          })
 
-    d.emit(
-        {
-            "posttime" => "2016-11-31T00:00:00Z"
-        }, time)
-
-    data = d.run
+      d.feed(
+          time,
+          {
+              "posttime" => "2016-11-31T00:00:00Z"
+          })
+    end
     puts data
     # ### FileOutput#write returns path
     # path = d.run
@@ -90,4 +98,3 @@ class AzureFunctionsOutputTest < Test::Unit::TestCase
     # assert_equal expect_path, path
   end
 end
-


### PR DESCRIPTION
I've tried to migrate to use v0.14 Output Plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks,